### PR TITLE
Replaced Animated.Text.propTypes.style with Text.propTypes.style

### DIFF
--- a/src/components/button/index.js
+++ b/src/components/button/index.js
@@ -71,7 +71,7 @@ export default class Button extends PureComponent {
       let { disableAnimation } = this.state;
 
       Animated
-        .timing(disableAnimation, { toValue: disabled? 1 : 0, duration })
+        .timing(disableAnimation, { useNativeDriver: true, toValue: disabled? 1 : 0, duration })
         .start();
     }
   }
@@ -93,6 +93,7 @@ export default class Button extends PureComponent {
         toValue: focused? 1 : 0,
         duration: focusAnimationDuration,
         easing: Easing.out(Easing.ease),
+        useNativeDriver: true,
       })
       .start();
   }

--- a/src/components/raised-text-button/index.js
+++ b/src/components/raised-text-button/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated } from 'react-native';
+import { Animated, Text } from 'react-native';
 
 import RaisedButton from '../raised-button';
 import { styles } from './styles';
@@ -16,7 +16,7 @@ export default class RaisedTextButton extends PureComponent {
 
     title: PropTypes.string.isRequired,
     titleColor: PropTypes.string,
-    titleStyle: Animated.Text.propTypes.style,
+    titleStyle: Text.propTypes.style,
     disabledTitleColor: PropTypes.string,
   };
 

--- a/src/components/text-button/index.js
+++ b/src/components/text-button/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated } from 'react-native';
+import { Animated, Text } from 'react-native';
 
 import Button from '../button';
 import { styles } from './styles';
@@ -21,7 +21,7 @@ export default class TextButton extends PureComponent {
 
     title: PropTypes.string.isRequired,
     titleColor: PropTypes.string,
-    titleStyle: Animated.Text.propTypes.style,
+    titleStyle: Text.propTypes.style,
     disabledTitleColor: PropTypes.string,
   };
 


### PR DESCRIPTION
Issue on prod release and React Native >= .0.62 fixed.

Error: Requiring module "node-modules/react-native-material-buttons/index.js", which threw an exception: **TypeError: undefined is not an object (evaluating '_reactNative.Animated.Text.propTypes.style'**
