### PR TITLE
Fix for https://github.com/n4kz/react-native-material-buttons/issues/11

### DIFF
--- a/src/components/raised-text-button/index.js
+++ b/src/components/raised-text-button/index.js
@@ -16,7 +16,6 @@ export default class RaisedTextButton extends PureComponent {
 
     title: PropTypes.string.isRequired,
     titleColor: PropTypes.string,
-    titleStyle: Animated.Text.propTypes.style,
     disabledTitleColor: PropTypes.string,
   };
 

--- a/src/components/text-button/index.js
+++ b/src/components/text-button/index.js
@@ -21,7 +21,6 @@ export default class TextButton extends PureComponent {
 
     title: PropTypes.string.isRequired,
     titleColor: PropTypes.string,
-    titleStyle: Animated.Text.propTypes.style,
     disabledTitleColor: PropTypes.string,
   };
 


### PR DESCRIPTION
It's hotfix for https://github.com/n4kz/react-native-material-buttons/issues/11
RN 0.62.2 is not support Animated.Text.propTypes.style